### PR TITLE
Update to image 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding"]
 license = "MIT"
 
 [dependencies]
-image = "0.23.0"
+image = "0.25"
 
 [badges]
 travis-ci = { repository = "teovoinea/steganography" }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -12,7 +12,7 @@ pub struct Encoder<'a> {
 impl<'a> Encoder<'a> {
 	/// Creates a new encoder with a buffer to write and an image to write it to
 	pub fn new(input: &[u8], img: DynamicImage) -> Encoder {
-		let img_as_rgba: ImageBuffer<Rgba<u8>, Vec<u8>> = img.to_rgba();
+		let img_as_rgba: ImageBuffer<Rgba<u8>, Vec<u8>> = img.to_rgba8();
 		Encoder{
 			img: img_as_rgba,
 			input

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,7 +44,7 @@ pub fn file_as_dynamic_image(filename: String) -> DynamicImage {
 
 pub fn file_as_image_buffer(filename: String) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
     let img = open(&Path::new(&filename)).unwrap();
-    img.to_rgba()
+    img.to_rgba8()
 }
 
 pub fn save_image_buffer(img: ImageBuffer<Rgba<u8>, Vec<u8>>, filename: String) {


### PR DESCRIPTION
The `image` crate had CVE-2020-35916 registered against it. 

This pull request updates the `image` crate to version `0.25` and leaves off the patch version to ensure library users can get patch updates.